### PR TITLE
Zobrist Hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,7 @@ version = "0.1.0"
 dependencies = [
  "derive_more",
  "rand",
+ "rand_chacha",
 ]
 
 [[package]]

--- a/chess-lib/Cargo.toml
+++ b/chess-lib/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 [dependencies]
 derive_more = "0.99.13"
 rand = "0.8.3"
+rand_chacha = "0.3.0"

--- a/chess-lib/src/fen.rs
+++ b/chess-lib/src/fen.rs
@@ -80,13 +80,13 @@ pub fn load_fen(fen: &str) -> GameState {
         _ => Some(parse_coord(en_passant_field)),
     };
 
-    GameState{
+    GameState::new(
         active_colour,
         white,
         black,
         en_passant,
-        fifty_move_clock: 0,
-    }
+        0,
+    )
 }
 
 #[cfg(test)]

--- a/chess-lib/src/fmt.rs
+++ b/chess-lib/src/fmt.rs
@@ -1,4 +1,35 @@
-use crate::types::{BitCoord, Move, Piece};
+use crate::types::{BitCoord, Colour, GameState, Move, Piece};
+
+impl std::fmt::Display for GameState {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        format_board(self, formatter)?;
+        Ok(())
+    }
+}
+
+pub fn format_board(state: &GameState, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    writeln!(formatter, " ------------------------------- ")?;
+    for rank in (0..8u32).rev() {
+        write!(formatter, "|")?;
+        for file in 0..8u32 {
+            let coord: BitCoord = (file, rank).into();
+            write!(formatter, " ")?;
+            match state.find_piece(coord) {
+                Some((c, pc)) => {
+                    match c {
+                        Colour::White => write!(formatter, "{}", format_piece(pc))?,
+                        Colour::Black => write!(formatter, "{}", format_piece(pc).to_lowercase())?,
+                    }
+                },
+                None => write!(formatter, " ")?,
+            }
+            write!(formatter, " |")?;
+        }
+        writeln!(formatter)?;
+        writeln!(formatter, " ------------------------------- ")?;
+    }
+    Ok(())
+}
 
 pub fn format_piece(piece: Piece) -> char {
     match piece {
@@ -8,6 +39,20 @@ pub fn format_piece(piece: Piece) -> char {
         Piece::Bishop => 'B',
         Piece::Knight => 'N',
         Piece::Pawn => 'P',
+    }
+}
+
+impl std::fmt::Debug for Move {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(formatter, "{}", format_move(*self))?;
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for BitCoord {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(formatter, "{}", format_coord(*self))?;
+        Ok(())
     }
 }
 

--- a/chess-lib/src/game.rs
+++ b/chess-lib/src/game.rs
@@ -1,72 +1,92 @@
 use crate::magic::MagicBitBoards;
 use crate::moves::square_under_attack;
-use crate::types::{BitBoard, BitCoord, Colour, GameState, Move, Piece};
+use crate::types::{BitBoard, BitCoord, Colour, GameState, Move, Piece, SideState, ZobristHash};
+use crate::zobrist::ZobristHasher;
 
 impl GameState {
+    pub fn new(
+        active_colour: Colour, 
+        white: SideState,
+        black: SideState,
+        en_passant: Option<BitCoord>,
+        fifty_move_clock: u8,
+    ) -> GameState {
+        let mut state = GameState{
+            active_colour,
+            white,
+            black,
+            en_passant,
+            fifty_move_clock,
+            zh: ZobristHash(0),
+        };
+
+        state.zh = ZobristHasher::default().hash(&state);
+
+        state
+    }
+
     pub fn make_move(&mut self, mv: Move) {
+        let hasher = ZobristHasher::default();
+
         self.fifty_move_clock += 1;
 
         match mv {
             Move::Normal(piece, src, tgt) => {
-                self.move_piece(piece, src, tgt);
+                self.move_piece(piece, src, tgt, hasher);
             },
             Move::Promotion(src, tgt, pc) => {
-                self.move_piece(Piece::Pawn, src, tgt);
-
-                let active_side = match self.active_colour {
-                    Colour::White => &mut self.white,
-                    Colour::Black => &mut self.black,
-                };
-                active_side.pieces.remove_piece(Piece::Pawn, tgt.into());
-                active_side.pieces.put_piece(pc, tgt.into());
+                self.move_piece(Piece::Pawn, src, tgt, hasher);
+                self.remove_active_piece(Piece::Pawn, tgt, hasher);
+                self.put_active_piece(pc, tgt, hasher);
             },
             Move::Castle => {
                 match self.active_colour {
                     Colour::White => {
-                        self.white.pieces.remove_piece(Piece::King, BitCoord(0x00_00_00_00_00_00_00_08));
-                        self.white.pieces.remove_piece(Piece::Rook, BitCoord(0x00_00_00_00_00_00_00_01));
-                        self.white.pieces.put_piece(Piece::King, BitCoord(0x00_00_00_00_00_00_00_02));
-                        self.white.pieces.put_piece(Piece::Rook, BitCoord(0x00_00_00_00_00_00_00_04));
-                        self.white.can_castle_kingside = false;
-                        self.white.can_castle_queenside = false;
-                        self.en_passant = None;
+                        self.remove_active_piece(Piece::King, BitCoord(0x00_00_00_00_00_00_00_08), hasher);
+                        self.remove_active_piece(Piece::Rook, BitCoord(0x00_00_00_00_00_00_00_01), hasher);
+                        self.put_active_piece(Piece::King, BitCoord(0x00_00_00_00_00_00_00_02), hasher);
+                        self.put_active_piece(Piece::Rook, BitCoord(0x00_00_00_00_00_00_00_04), hasher);
+                        self.disable_active_kingside_castle(hasher);
+                        self.disable_active_queenside_castle(hasher);
+                        self.clear_en_passant(hasher);
                     },
                     Colour::Black => {
-                        self.black.pieces.remove_piece(Piece::King, BitCoord(0x08_00_00_00_00_00_00_00));
-                        self.black.pieces.remove_piece(Piece::Rook, BitCoord(0x01_00_00_00_00_00_00_00));
-                        self.black.pieces.put_piece(Piece::King, BitCoord(0x02_00_00_00_00_00_00_00));
-                        self.black.pieces.put_piece(Piece::Rook, BitCoord(0x04_00_00_00_00_00_00_00));
-                        self.black.can_castle_kingside = false;
-                        self.black.can_castle_queenside = false;
-                        self.en_passant = None;
+                        self.remove_active_piece(Piece::King, BitCoord(0x08_00_00_00_00_00_00_00), hasher);
+                        self.remove_active_piece(Piece::Rook, BitCoord(0x01_00_00_00_00_00_00_00), hasher);
+                        self.put_active_piece(Piece::King, BitCoord(0x02_00_00_00_00_00_00_00), hasher);
+                        self.put_active_piece(Piece::Rook, BitCoord(0x04_00_00_00_00_00_00_00), hasher);
+                        self.disable_active_kingside_castle(hasher);
+                        self.disable_active_queenside_castle(hasher);
+                        self.clear_en_passant(hasher);
                     },
                 }
             },
             Move::LongCastle => {
                 match self.active_colour {
                     Colour::White => {
-                        self.white.pieces.remove_piece(Piece::King, BitCoord(0x00_00_00_00_00_00_00_08));
-                        self.white.pieces.remove_piece(Piece::Rook, BitCoord(0x00_00_00_00_00_00_00_80));
-                        self.white.pieces.put_piece(Piece::King, BitCoord(0x00_00_00_00_00_00_00_20));
-                        self.white.pieces.put_piece(Piece::Rook, BitCoord(0x00_00_00_00_00_00_00_10));
-                        self.white.can_castle_kingside = false;
-                        self.white.can_castle_queenside = false;
-                        self.en_passant = None;
+                        self.remove_active_piece(Piece::King, BitCoord(0x00_00_00_00_00_00_00_08), hasher);
+                        self.remove_active_piece(Piece::Rook, BitCoord(0x00_00_00_00_00_00_00_80), hasher);
+                        self.put_active_piece(Piece::King, BitCoord(0x00_00_00_00_00_00_00_20), hasher);
+                        self.put_active_piece(Piece::Rook, BitCoord(0x00_00_00_00_00_00_00_10), hasher);
+                        self.disable_active_kingside_castle(hasher);
+                        self.disable_active_queenside_castle(hasher);
+                        self.clear_en_passant(hasher);
                     },
                     Colour::Black => {
-                        self.black.pieces.remove_piece(Piece::King, BitCoord(0x08_00_00_00_00_00_00_00));
-                        self.black.pieces.remove_piece(Piece::Rook, BitCoord(0x80_00_00_00_00_00_00_00));
-                        self.black.pieces.put_piece(Piece::King, BitCoord(0x20_00_00_00_00_00_00_00));
-                        self.black.pieces.put_piece(Piece::Rook, BitCoord(0x10_00_00_00_00_00_00_00));
-                        self.black.can_castle_kingside = false;
-                        self.black.can_castle_queenside = false;
-                        self.en_passant = None;
+                        self.remove_active_piece(Piece::King, BitCoord(0x08_00_00_00_00_00_00_00), hasher);
+                        self.remove_active_piece(Piece::Rook, BitCoord(0x80_00_00_00_00_00_00_00), hasher);
+                        self.put_active_piece(Piece::King, BitCoord(0x20_00_00_00_00_00_00_00), hasher);
+                        self.put_active_piece(Piece::Rook, BitCoord(0x10_00_00_00_00_00_00_00), hasher);
+                        self.disable_active_kingside_castle(hasher);
+                        self.disable_active_queenside_castle(hasher);
+                        self.clear_en_passant(hasher);
                     },
                 }
             },
         }
 
         self.active_colour = Colour::other(self.active_colour);
+        self.zh = hasher.toggle_active_colour(self.zh);
     }
 
     pub fn is_in_check(&self, mbb: &MagicBitBoards) -> bool {
@@ -94,14 +114,8 @@ impl GameState {
         None
     }
 
-    fn move_piece(&mut self, piece: Piece, src: BitCoord, tgt: BitCoord) {
+    fn move_piece(&mut self, piece: Piece, src: BitCoord, tgt: BitCoord, hasher: &ZobristHasher) {
         let colour = self.active_colour;
-
-        let (active_side, other_side) = match colour {
-            Colour::White => (&mut self.white, &mut self.black),
-            Colour::Black => (&mut self.black, &mut self.white),
-        };
-
 
         let home_rank = match colour {
             Colour::White => BitBoard(0x00_00_00_00_00_00_00_FF),
@@ -118,52 +132,135 @@ impl GameState {
         let other_queenside_rook: BitCoord = BitCoord(other_home_rank.0 & 0x80_00_00_00_00_00_00_80);
         let other_kingside_rook: BitCoord = BitCoord(other_home_rank.0 & 0x01_00_00_00_00_00_00_01);
 
-        let is_capture = other_side.pieces.all() & tgt != BitBoard::EMPTY;
         let is_pawn = piece == Piece::Pawn;
 
-        active_side.pieces.remove_piece(piece, src);
-        active_side.pieces.put_piece(piece, tgt);
-        other_side.pieces.clear_square(tgt);
+        self.remove_active_piece(piece, src, hasher);
+        self.put_active_piece(piece, tgt, hasher);
+        let mut is_capture = match self.other_side_mut().pieces.get_piece(tgt) {
+            Some(pc) => {
+                self.remove_other_piece(pc, tgt, hasher);
+                true
+            },
+            None => false,
+        };
 
         if is_pawn && self.en_passant.map(|ep| ep == tgt).unwrap_or(false) {
             let taken_coord = match colour {
                 Colour::White => tgt >> 8,
                 Colour::Black => tgt << 8,
             };
-            other_side.pieces.remove_piece(Piece::Pawn, taken_coord);
+            self.remove_other_piece(Piece::Pawn, taken_coord, hasher);
+            is_capture = true;
         }
 
         // King moves.
         if piece == Piece::King {
-            active_side.can_castle_queenside = false;
-            active_side.can_castle_kingside = false;
+            self.disable_active_kingside_castle(hasher);
+            self.disable_active_queenside_castle(hasher);
         }
 
         if src == queenside_rook {
-            active_side.can_castle_queenside = false;
+            self.disable_active_queenside_castle(hasher);
         } else if src == kingside_rook {
-            active_side.can_castle_kingside = false;
+            self.disable_active_kingside_castle(hasher);
         }
 
         if tgt == other_queenside_rook {
-            other_side.can_castle_queenside = false;
+            self.disable_other_queenside_castle(hasher);
         } else if tgt == other_kingside_rook {
-            other_side.can_castle_kingside = false;
+            self.disable_other_kingside_castle(hasher);
         }
 
         // Check for En Passant.
         if is_pawn && (src == tgt << 16 || src == tgt >> 16) {
-            self.en_passant = match colour {
-                Colour::White => Some(tgt >> 8),
-                Colour::Black => Some(tgt << 8),
+            let ep = match colour {
+                Colour::White => tgt >> 8,
+                Colour::Black => tgt << 8,
             };
+            self.set_en_passant(ep, hasher);
         } else {
-            self.en_passant = None;
+            self.clear_en_passant(hasher);
         }
 
         // Adjust clocks.
         if is_pawn || is_capture {
             self.fifty_move_clock = 0;
+        }
+    }
+
+    fn put_active_piece(&mut self, piece: Piece, coord: BitCoord, hasher: &ZobristHasher) {
+        self.active_side_mut().pieces.put_piece(piece, coord);
+        self.zh = hasher.toggle_piece(self.zh, self.active_colour, piece, coord);
+    }
+
+    fn remove_active_piece(&mut self, piece: Piece, coord: BitCoord, hasher: &ZobristHasher) {
+        self.active_side_mut().pieces.remove_piece(piece, coord);
+        self.zh = hasher.toggle_piece(self.zh, self.active_colour, piece, coord);
+    }
+
+    fn remove_other_piece(&mut self, piece: Piece, coord: BitCoord, hasher: &ZobristHasher) {
+        self.other_side_mut().pieces.remove_piece(piece, coord);
+        self.zh = hasher.toggle_piece(self.zh, Colour::other(self.active_colour), piece, coord);
+    }
+
+    fn set_en_passant(&mut self, coord: BitCoord, hasher: &ZobristHasher) {
+        match self.en_passant.replace(coord) {
+            Some(prev) => self.zh = hasher.toggle_en_passant(self.zh, prev),
+            None => (),
+        };
+        self.zh = hasher.toggle_en_passant(self.zh, coord);
+    }
+
+    fn clear_en_passant(&mut self, hasher: &ZobristHasher) {
+        match self.en_passant.take() {
+            Some(coord) => self.zh = hasher.toggle_en_passant(self.zh, coord),
+            None => (),
+        };
+    }
+
+    fn disable_active_queenside_castle(&mut self, hasher: &ZobristHasher) {
+        self.active_side_mut().can_castle_queenside = false;
+        self.zh = match self.active_colour {
+            Colour::White => hasher.toggle_white_queenside(self.zh),
+            Colour::Black => hasher.toggle_black_queenside(self.zh),
+        };
+    }
+
+    fn disable_active_kingside_castle(&mut self, hasher: &ZobristHasher) {
+        self.active_side_mut().can_castle_kingside = false;
+        self.zh = match self.active_colour {
+            Colour::White => hasher.toggle_white_kingside(self.zh),
+            Colour::Black => hasher.toggle_black_kingside(self.zh),
+        };
+    }
+
+    fn disable_other_queenside_castle(&mut self, hasher: &ZobristHasher) {
+        self.other_side_mut().can_castle_queenside = false;
+        self.zh = match self.active_colour {
+            Colour::White => hasher.toggle_black_queenside(self.zh),
+            Colour::Black => hasher.toggle_white_queenside(self.zh),
+        };
+    }
+
+    fn disable_other_kingside_castle(&mut self, hasher: &ZobristHasher) {
+        self.other_side_mut().can_castle_kingside = false;
+        self.zh = match self.active_colour {
+            Colour::White => hasher.toggle_black_kingside(self.zh),
+            Colour::Black => hasher.toggle_white_kingside(self.zh),
+        };
+    }
+
+    fn active_side_mut(&mut self) -> &mut SideState {
+        match self.active_colour {
+            Colour::White => &mut self.white,
+            Colour::Black => &mut self.black,
+        }
+    }
+
+    fn other_side_mut(&mut self) -> &mut SideState {
+        match self.active_colour {
+            Colour::White => &mut self.black,
+            Colour::Black => &mut self.white,
         }
     }
 }

--- a/chess-lib/src/game.rs
+++ b/chess-lib/src/game.rs
@@ -28,7 +28,7 @@ impl GameState {
     pub fn make_move(&mut self, mv: Move) {
         let hasher = ZobristHasher::default();
 
-        self.fifty_move_clock += 1;
+        self.fifty_move_clock = self.fifty_move_clock.saturating_add(1);
 
         match mv {
             Move::Normal(piece, src, tgt) => {
@@ -219,35 +219,47 @@ impl GameState {
     }
 
     fn disable_active_queenside_castle(&mut self, hasher: &ZobristHasher) {
-        self.active_side_mut().can_castle_queenside = false;
-        self.zh = match self.active_colour {
-            Colour::White => hasher.toggle_white_queenside(self.zh),
-            Colour::Black => hasher.toggle_black_queenside(self.zh),
-        };
+        let side = self.active_side_mut();
+        if side.can_castle_queenside {
+            side.can_castle_queenside = false;
+            self.zh = match self.active_colour {
+                Colour::White => hasher.toggle_white_queenside(self.zh),
+                Colour::Black => hasher.toggle_black_queenside(self.zh),
+            };
+        }
     }
 
     fn disable_active_kingside_castle(&mut self, hasher: &ZobristHasher) {
-        self.active_side_mut().can_castle_kingside = false;
-        self.zh = match self.active_colour {
-            Colour::White => hasher.toggle_white_kingside(self.zh),
-            Colour::Black => hasher.toggle_black_kingside(self.zh),
-        };
+        let side = self.active_side_mut();
+        if side.can_castle_kingside {
+            side.can_castle_kingside = false;
+            self.zh = match self.active_colour {
+                Colour::White => hasher.toggle_white_kingside(self.zh),
+                Colour::Black => hasher.toggle_black_kingside(self.zh),
+            };
+        }
     }
 
     fn disable_other_queenside_castle(&mut self, hasher: &ZobristHasher) {
-        self.other_side_mut().can_castle_queenside = false;
-        self.zh = match self.active_colour {
-            Colour::White => hasher.toggle_black_queenside(self.zh),
-            Colour::Black => hasher.toggle_white_queenside(self.zh),
-        };
+        let side = self.other_side_mut();
+        if side.can_castle_queenside {
+            side.can_castle_queenside = false;
+            self.zh = match self.active_colour {
+                Colour::White => hasher.toggle_black_queenside(self.zh),
+                Colour::Black => hasher.toggle_white_queenside(self.zh),
+            };
+        }
     }
 
     fn disable_other_kingside_castle(&mut self, hasher: &ZobristHasher) {
-        self.other_side_mut().can_castle_kingside = false;
-        self.zh = match self.active_colour {
-            Colour::White => hasher.toggle_black_kingside(self.zh),
-            Colour::Black => hasher.toggle_white_kingside(self.zh),
-        };
+        let side = self.other_side_mut();
+        if side.can_castle_kingside {
+            side.can_castle_kingside = false;
+            self.zh = match self.active_colour {
+                Colour::White => hasher.toggle_black_kingside(self.zh),
+                Colour::Black => hasher.toggle_white_kingside(self.zh),
+            };
+        }
     }
 
     fn active_side_mut(&mut self) -> &mut SideState {

--- a/chess-lib/src/lib.rs
+++ b/chess-lib/src/lib.rs
@@ -7,6 +7,7 @@ pub mod moves;
 pub mod perft;
 pub mod pgn;
 pub mod types;
+pub mod zobrist;
 
 #[cfg(test)]
 mod tests {

--- a/chess-lib/src/magic.rs
+++ b/chess-lib/src/magic.rs
@@ -426,7 +426,8 @@ mod generated {
 
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
+    use rand::prelude::*;
+    use rand_chacha::ChaCha8Rng;
     use crate::magic::*;
     use crate::types::{BitBoard};
 
@@ -460,7 +461,7 @@ mod tests {
 
     #[test]
     fn test_generate_rook() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha8Rng::seed_from_u64(12345);
         // Test a few random configurations.
         for _ in 0..100 {
             let coord = BitCoord(1 << (rng.gen_range(0..64)));
@@ -491,7 +492,7 @@ mod tests {
 
     #[test]
     fn test_generated_rook_magic() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha8Rng::seed_from_u64(12345);
         let magic_bbs = MagicBitBoards::default();
 
         for _ in 0..100_000 {
@@ -510,7 +511,7 @@ mod tests {
 
     #[test]
     fn test_generated_bishop_magic() {
-        let mut rng = rand::thread_rng();
+        let mut rng = ChaCha8Rng::seed_from_u64(12345);
         let magic_bbs = MagicBitBoards::default();
 
         for _ in 0..100_000 {

--- a/chess-lib/src/types.rs
+++ b/chess-lib/src/types.rs
@@ -6,6 +6,18 @@ pub struct GameState {
     pub black: SideState,
     pub en_passant: Option<BitCoord>,
     pub fifty_move_clock: u8,
+    pub zh: ZobristHash,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ZobristHash(pub u64);
+
+impl std::ops::BitXor<u64> for ZobristHash {
+    type Output = ZobristHash;
+
+    fn bitxor(self, rhs: u64) -> Self::Output {
+        ZobristHash(self.0 ^ rhs)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/chess-lib/src/types.rs
+++ b/chess-lib/src/types.rs
@@ -246,7 +246,7 @@ impl Iterator for BitBoardIter {
 }
 
 // u64 with exactly 1 bit filled, representing a square.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
 pub struct BitCoord(pub u64);
 
 impl BitCoord {
@@ -325,7 +325,7 @@ impl From<u64> for BitCoord {
     }
 }
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
 pub enum Move {
     Normal(Piece, BitCoord, BitCoord),
     Promotion(BitCoord, BitCoord, Piece),

--- a/chess-lib/src/zobrist.rs
+++ b/chess-lib/src/zobrist.rs
@@ -12,6 +12,7 @@ pub struct ZobristHasher {
 }
 
 impl ZobristHasher {
+    const DEFAULT_SEED: u64 = 26355;
     const BLACK_TO_MOVE: usize = 12 * 64;
     const WHITE_QUEENSIDE: usize = 12 * 64 + 1;
     const WHITE_KINGSIDE: usize = 12 * 64 + 1;
@@ -21,7 +22,7 @@ impl ZobristHasher {
 
     pub fn default() -> &'static ZobristHasher {
         unsafe {
-            DEFAULT_HASHER.get_or_insert_with(|| Self::from_seed(12345))
+            DEFAULT_HASHER.get_or_insert_with(|| Self::from_seed(Self::DEFAULT_SEED))
         }
     }
 
@@ -146,10 +147,10 @@ mod tests {
     #[test]
     fn from_scratch() {
         // Tests that the hasher does something, and remains deterministic.
-        let hasher = ZobristHasher::from_seed(12345);
+        let hasher = ZobristHasher::default();
         let state = load_fen(STARTING_POSITION);
         let zh = hasher.hash(&state);
-        assert_eq!(zh, ZobristHash(0x165167d9c9a46d4b));
+        assert_eq!(zh, ZobristHash(0x5aba4aaed7d93fd));
     }
 }
 

--- a/chess-lib/src/zobrist.rs
+++ b/chess-lib/src/zobrist.rs
@@ -1,0 +1,158 @@
+use rand::prelude::*;
+use rand_chacha::ChaCha8Rng;
+
+use crate::types::{BitBoard, BitCoord, Colour, GameState, Piece};
+
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ZobristHash(u64);
+
+impl std::ops::BitXor<u64> for ZobristHash {
+    type Output = ZobristHash;
+
+    fn bitxor(self, rhs: u64) -> Self::Output {
+        ZobristHash(self.0 ^ rhs)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ZobristHasher {
+    numbers: [u64; 781],
+}
+
+impl ZobristHasher {
+    const BLACK_TO_MOVE: usize = 12 * 64;
+    const WHITE_QUEENSIDE: usize = 12 * 64 + 1;
+    const WHITE_KINGSIDE: usize = 12 * 64 + 1;
+    const BLACK_QUEENSIDE: usize = 12 * 64 + 2;
+    const BLACK_KINGSIDE: usize = 12 * 64 + 3;
+    const EN_PASSANT: usize = 12 * 64 + 4;
+
+    pub fn from_seed(seed: u64) -> ZobristHasher {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let mut numbers = [0u64; 781];
+        for ix in 0..781 {
+            numbers[ix] = rng.gen();
+        }
+
+        ZobristHasher{numbers}
+    }
+
+    pub fn hash(&self, state: &GameState) -> ZobristHash {
+        let mut zh = ZobristHash(0);
+
+        zh = self.toggle_pieces(zh, Colour::White, Piece::King, state.white.pieces.king);
+        zh = self.toggle_pieces(zh, Colour::White, Piece::Queen, state.white.pieces.queens);
+        zh = self.toggle_pieces(zh, Colour::White, Piece::Rook, state.white.pieces.rooks);
+        zh = self.toggle_pieces(zh, Colour::White, Piece::Bishop, state.white.pieces.bishops);
+        zh = self.toggle_pieces(zh, Colour::White, Piece::Knight, state.white.pieces.knights);
+        zh = self.toggle_pieces(zh, Colour::White, Piece::Pawn, state.white.pieces.pawns);
+
+        zh = self.toggle_pieces(zh, Colour::Black, Piece::King, state.black.pieces.king);
+        zh = self.toggle_pieces(zh, Colour::Black, Piece::Queen, state.black.pieces.queens);
+        zh = self.toggle_pieces(zh, Colour::Black, Piece::Rook, state.black.pieces.rooks);
+        zh = self.toggle_pieces(zh, Colour::Black, Piece::Bishop, state.black.pieces.bishops);
+        zh = self.toggle_pieces(zh, Colour::Black, Piece::Knight, state.black.pieces.knights);
+        zh = self.toggle_pieces(zh, Colour::Black, Piece::Pawn, state.black.pieces.pawns);
+
+        if state.active_colour == Colour::Black {
+            zh = self.toggle_active_colour(zh);
+        }
+
+        if state.white.can_castle_queenside {
+            zh = self.toggle_white_queenside(zh);
+        }
+
+        if state.white.can_castle_kingside {
+            zh = self.toggle_white_kingside(zh);
+        }
+
+        if state.black.can_castle_queenside {
+            zh = self.toggle_black_queenside(zh);
+        }
+
+        if state.black.can_castle_kingside {
+            zh = self.toggle_black_kingside(zh);
+        }
+
+        match state.en_passant {
+            Some(ep) => zh = self.toggle_en_passant(zh, ep),
+            None => (),
+        }
+
+        zh
+    }
+
+    pub fn toggle_active_colour(&self, zh: ZobristHash) -> ZobristHash {
+        zh ^ self.numbers[Self::BLACK_TO_MOVE]
+    }
+
+    pub fn toggle_piece(&self, zh: ZobristHash, colour: Colour, piece: Piece, coord: BitCoord) -> ZobristHash {
+       zh ^ self.numbers[Self::piece_index(colour, piece, coord)]
+    }
+
+    pub fn toggle_en_passant(&self, zh: ZobristHash, en_passant: BitCoord) -> ZobristHash {
+        let ep_file = en_passant.file() as usize;
+        let ep_file_ix = Self::EN_PASSANT + ep_file;
+        zh ^ self.numbers[ep_file_ix]
+    }
+
+    pub fn toggle_white_queenside(&self, zh: ZobristHash) -> ZobristHash {
+        zh ^ self.numbers[Self::WHITE_QUEENSIDE]
+    }
+
+    pub fn toggle_white_kingside(&self, zh: ZobristHash) -> ZobristHash {
+        zh ^ self.numbers[Self::WHITE_KINGSIDE]
+    }
+
+    pub fn toggle_black_queenside(&self, zh: ZobristHash) -> ZobristHash {
+        zh ^ self.numbers[Self::BLACK_QUEENSIDE]
+    }
+
+    pub fn toggle_black_kingside(&self, zh: ZobristHash) -> ZobristHash {
+        zh ^ self.numbers[Self::BLACK_KINGSIDE]
+    }
+
+    fn toggle_pieces(&self, mut zh: ZobristHash, colour: Colour, piece: Piece, bb: BitBoard) -> ZobristHash {
+        for coord in bb.iter() {
+           zh = self.toggle_piece(zh, colour, piece, coord);
+        }
+        zh
+    }
+
+    fn piece_index(colour: Colour, piece: Piece, coord: BitCoord) -> usize {
+        let coord_ix: usize = coord.0.trailing_zeros() as usize;
+
+        let piece_ix: usize = match piece {
+            Piece::King => 0 * 64,
+            Piece::Queen => 1 * 64,
+            Piece::Rook => 2 * 64,
+            Piece::Bishop => 3 * 64,
+            Piece::Knight => 4 * 64,
+            Piece::Pawn => 5 * 64,
+        };
+
+        let colour_ix: usize = match colour {
+            Colour::White => 0 * 6 * 64,
+            Colour::Black => 1 * 6 * 64,
+        };
+
+        colour_ix + piece_ix + coord_ix
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::fen::*;
+    use crate::zobrist::*;
+
+    #[test]
+    fn from_scratch() {
+        // Tests that the hasher does something, and remains deterministic.
+        let hasher = ZobristHasher::from_seed(12345);
+        let state = load_fen(STARTING_POSITION);
+        let zh = hasher.hash(&state);
+        assert_eq!(zh, ZobristHash(0x165167d9c9a46d4b));
+    }
+}
+

--- a/chess-lib/src/zobrist.rs
+++ b/chess-lib/src/zobrist.rs
@@ -1,19 +1,10 @@
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 
-use crate::types::{BitBoard, BitCoord, Colour, GameState, Piece};
+use crate::types::{BitBoard, BitCoord, Colour, GameState, Piece, ZobristHash};
 
+static mut DEFAULT_HASHER: Option<ZobristHasher> = None;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ZobristHash(u64);
-
-impl std::ops::BitXor<u64> for ZobristHash {
-    type Output = ZobristHash;
-
-    fn bitxor(self, rhs: u64) -> Self::Output {
-        ZobristHash(self.0 ^ rhs)
-    }
-}
 
 #[derive(Clone, Copy, Debug)]
 pub struct ZobristHasher {
@@ -27,6 +18,12 @@ impl ZobristHasher {
     const BLACK_QUEENSIDE: usize = 12 * 64 + 2;
     const BLACK_KINGSIDE: usize = 12 * 64 + 3;
     const EN_PASSANT: usize = 12 * 64 + 4;
+
+    pub fn default() -> &'static ZobristHasher {
+        unsafe {
+            DEFAULT_HASHER.get_or_insert_with(|| Self::from_seed(12345))
+        }
+    }
 
     pub fn from_seed(seed: u64) -> ZobristHasher {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);

--- a/chess-lib/src/zobrist.rs
+++ b/chess-lib/src/zobrist.rs
@@ -36,6 +36,16 @@ impl ZobristHasher {
         ZobristHasher{numbers}
     }
 
+    pub fn identify_diff(&self, lhs: ZobristHash, rhs: ZobristHash) -> Option<usize> {
+        let diff = lhs.0 ^ rhs.0;
+        for ix in 0..781 {
+            if diff == self.numbers[ix] {
+                return Some(ix);
+            }
+        }
+        None
+    }
+
     pub fn hash(&self, state: &GameState) -> ZobristHash {
         let mut zh = ZobristHash(0);
 

--- a/chess-lib/tests/chaos.rs
+++ b/chess-lib/tests/chaos.rs
@@ -1,0 +1,47 @@
+use rand::prelude::*;
+use rand_chacha::ChaCha8Rng;
+use chess_lib::fen::{load_fen, STARTING_POSITION};
+use chess_lib::magic::MagicBitBoards;
+use chess_lib::moves::legal_moves;
+use chess_lib::types::Move;
+use chess_lib::zobrist::ZobristHasher;
+
+#[test]
+fn zobrist_chaos() {
+    // Tests that incrementally updated zobrist hash equals one computed from scratch.
+    let mut rng = ChaCha8Rng::seed_from_u64(12345);
+    let mbb = MagicBitBoards::default();
+    let hasher = ZobristHasher::default();
+    let mut state = load_fen(STARTING_POSITION);
+    let mut sequence: Vec<Move> = vec![];
+
+    for _ in 0..100_000 {
+        let moves = legal_moves(&state, &mbb);
+        match moves.choose(&mut rng) {
+            Some(mv) => {
+                state.make_move(*mv);
+                sequence.push(*mv);
+                let clean_hash = hasher.hash(&state);
+
+                if state.zh != clean_hash {
+                    println!("After these moves, the hash differs: {:?}", sequence);
+                    println!("Final board: \n{}", &state);
+                    println!("Hash difference: 0x{:16x}", state.zh.0 ^ clean_hash.0);
+                    println!("Identified error index: {:?}", hasher.identify_diff(state.zh, clean_hash));
+                    panic!("Test failed");
+                }
+            },
+            None => {
+                // No legal moves, reset game.
+                state = load_fen(STARTING_POSITION);
+                sequence.clear();
+            },
+        }
+
+        // Also reset after 50 moves.
+        if sequence.len() >= 50 {
+            state = load_fen(STARTING_POSITION);
+            sequence.clear();
+        }
+    }
+}


### PR DESCRIPTION
Compute and incrementally update zobrist hash for the board state.
Impact on perft is minimal.